### PR TITLE
Derive Debug for DeckError

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#cards-rs
+# cards-rs
 
 Reusable playing cards library for Rust. See the tests for usage examples. Cards are modelled as a tuple of Value and Suit, as can be seen in the *src/card.rs* file.
 
 The crate is called `cards` and you can depend on it via cargo:
 
 ```ini
-[dependencies.cards]
-git = "https://github.com/th4t/cards-rs.git"
+[dependencies]
+cards = "1.1.2"
 ```
 
 ## Related Crates

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -10,6 +10,7 @@ pub struct Deck {
     cards: [u8; 52],
 }
 
+#[derive(Debug)]
 pub enum DeckError {
     NotEnoughCards
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -89,3 +89,10 @@ fn reset_deck() {
     deck.reset_unshuffled();
     deck.draw_n(52).ok().unwrap();
 }
+
+#[test]
+#[should_panic]
+fn unwrap_deck_error(){
+    let mut deck = Deck::new_unshuffled();
+    deck.draw_n(53).unwrap();
+}


### PR DESCRIPTION
This change allows users of the library to `unwrap()` `Result`s without throwing the error type away.

## Examples

### Before Change

```rust
let mut deck = Deck::new_shuffled();
deck.draw_n(53).ok().unwrap();
```

Creates Error Message:

```
thread 'draw_too_many_cards' panicked at 'called `Option::unwrap()` on a `None` value'
```


### After Change

```rust
let mut deck = Deck::new_unshuffled();
deck.draw_n(53).unwrap();
```

Creates Error Message:

```
thread 'unwrap_deck_error' panicked at 'called `Result::unwrap()` on an `Err` value: NotEnoughCards'
```

