### PR TITLE
Use unicode suit characters for Card Suits

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -11,10 +11,10 @@ pub enum Suit {
 impl Suit {
     fn short_string(&self) -> &'static str {
         match *self {
-            Suit::Spades => "s",
-            Suit::Hearts => "h",
-            Suit::Diamonds => "d",
-            Suit::Clubs => "c",
+            Suit::Spades => "♤",
+            Suit::Hearts => "♡",
+            Suit::Diamonds => "♢",
+            Suit::Clubs => "♧",
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -89,3 +89,11 @@ fn reset_deck() {
     deck.reset_unshuffled();
     deck.draw_n(52).ok().unwrap();
 }
+
+#[test]
+fn card_display(){
+    assert_eq!("A♤", format!("{}",Card{value: Value::Ace, suit:Suit::Spades}));
+    assert_eq!("A♡", format!("{}",Card{value: Value::Ace, suit:Suit::Hearts}));
+    assert_eq!("A♢", format!("{}",Card{value: Value::Ace, suit:Suit::Diamonds}));
+    assert_eq!("A♧", format!("{}",Card{value: Value::Ace, suit:Suit::Clubs}));
+}


### PR DESCRIPTION
This takes advantage of Rust's char type being a unicode code point (just a matter of taste)