### PR TITLE
Feature/deck remove card

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -1,5 +1,11 @@
 use std::fmt;
 
+pub enum CardError {
+    SuitDoesNotExist,
+    ValueDoesNotExist,
+    CardDoesNotExist,
+}
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Ord, PartialOrd, Hash)]
 pub enum Suit {
     Spades,
@@ -15,6 +21,16 @@ impl Suit {
             Suit::Hearts => "h",
             Suit::Diamonds => "d",
             Suit::Clubs => "c",
+        }
+    }
+
+    fn from_value(value: u8) -> Result<Suit, CardError> {
+        match value / 13 {
+            0 => Ok(Suit::Spades),
+            1 => Ok(Suit::Hearts),
+            2 => Ok(Suit::Diamonds),
+            3 => Ok(Suit::Clubs),
+            _ => Err(CardError::SuitDoesNotExist),
         }
     }
 }
@@ -55,6 +71,25 @@ impl Value {
             Value::Ace => "A",
         }
     }
+
+    fn from_value(value: u8) -> Result<Value, CardError> {
+        match value % 13 {
+            0 => Ok(Value::Two),
+            1 => Ok(Value::Three),
+            2 => Ok(Value::Four),
+            3 => Ok(Value::Five),
+            4 => Ok(Value::Six),
+            5 => Ok(Value::Seven),
+            6 => Ok(Value::Eight),
+            7 => Ok(Value::Nine),
+            8 => Ok(Value::Ten),
+            9 => Ok(Value::Jack),
+            10 => Ok(Value::Queen),
+            11 => Ok(Value::King),
+            12 => Ok(Value::Ace),
+            _ => Err(CardError::ValueDoesNotExist),
+        }
+    }
 }
 
 //TODO: debug still relevant? It was used to print a vec of cards.
@@ -71,6 +106,20 @@ impl Card {
             value: value,
             suit: suit,
         }
+    }
+
+    pub(crate) fn from_value(v: u8) -> Result<Card, CardError> {
+        let value = match Value::from_value(v) {
+            Ok(v) => v,
+            Err(_) => return Err(CardError::CardDoesNotExist),
+        };
+
+        let suit = match Suit::from_value(v) {
+            Ok(s) => s,
+            Err(_) => return Err(CardError::CardDoesNotExist),
+        };
+
+        Ok(Card::new(value, suit))
     }
 }
 

--- a/src/card.rs
+++ b/src/card.rs
@@ -62,18 +62,26 @@ impl Value {
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Ord, PartialOrd, Hash)]
 pub struct Card {
     pub value: Value,
-    pub suit: Suit
+    pub suit: Suit,
 }
 
 impl Card {
     pub fn new(value: Value, suit: Suit) -> Card {
-        Card{ value: value, suit: suit }
+        Card {
+            value: value,
+            suit: suit,
+        }
     }
 }
 
 // so cards can be printed using fmt method
 impl fmt::Display for Card {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}{}", self.value.short_string(), self.suit.short_string())
+        write!(
+            f,
+            "{}{}",
+            self.value.short_string(),
+            self.suit.short_string()
+        )
     }
 }

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -1,7 +1,7 @@
 use rand;
-use rand::{Rng};
+use rand::Rng;
 
-use card::{Suit, Value, Card};
+use card::{Card, Suit, Value};
 
 pub struct Deck {
     count_dealt: usize,
@@ -11,20 +11,20 @@ pub struct Deck {
 }
 
 pub enum DeckError {
-    NotEnoughCards
+    NotEnoughCards,
 }
 
 /// translates a value between 0 and 51 to a Card. Used internally.
 fn create_card_for_value(value: u8) -> Card {
-    let suit = match value/13 {
+    let suit = match value / 13 {
         0 => Suit::Spades,
         1 => Suit::Hearts,
         2 => Suit::Diamonds,
         3 => Suit::Clubs,
-        _ => panic!("Unexpected suit conversion number")
+        _ => panic!("Unexpected suit conversion number"),
     };
 
-    let value = match value%13 {
+    let value = match value % 13 {
         0 => Value::Two,
         1 => Value::Three,
         2 => Value::Four,
@@ -38,7 +38,7 @@ fn create_card_for_value(value: u8) -> Card {
         10 => Value::Queen,
         11 => Value::King,
         12 => Value::Ace,
-        _ => panic!("Unexpected value conversion number")
+        _ => panic!("Unexpected value conversion number"),
     };
 
     Card::new(value, suit)
@@ -92,7 +92,7 @@ impl Deck {
             Err(DeckError::NotEnoughCards)
         } else {
             let value = self.cards[self.count_dealt];
-            self.count_dealt+=1;
+            self.count_dealt += 1;
 
             let card = create_card_for_value(value);
             Ok(card)

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -1,47 +1,16 @@
 use rand;
 use rand::Rng;
 
-use card::{Card, Suit, Value};
+use card::Card;
 
 pub struct Deck {
-    count_dealt: usize,
-    // TODO: consider turning this into a Vec<Card>, for iterator
-    // goodness. deck.next() producing Option<Card>?
-    cards: [u8; 52],
+    cards: Vec<Card>,
 }
 
+#[derive(Debug)]
 pub enum DeckError {
     NotEnoughCards,
-}
-
-/// translates a value between 0 and 51 to a Card. Used internally.
-fn create_card_for_value(value: u8) -> Card {
-    let suit = match value / 13 {
-        0 => Suit::Spades,
-        1 => Suit::Hearts,
-        2 => Suit::Diamonds,
-        3 => Suit::Clubs,
-        _ => panic!("Unexpected suit conversion number"),
-    };
-
-    let value = match value % 13 {
-        0 => Value::Two,
-        1 => Value::Three,
-        2 => Value::Four,
-        3 => Value::Five,
-        4 => Value::Six,
-        5 => Value::Seven,
-        6 => Value::Eight,
-        7 => Value::Nine,
-        8 => Value::Ten,
-        9 => Value::Jack,
-        10 => Value::Queen,
-        11 => Value::King,
-        12 => Value::Ace,
-        _ => panic!("Unexpected value conversion number"),
-    };
-
-    Card::new(value, suit)
+    CardNotInDeck,
 }
 
 /// A deck can be dealt from and shuffled.
@@ -50,15 +19,10 @@ impl Deck {
 
     /// Returns a deck where all cards are sorted by Suit, then by Value.
     pub fn new_unshuffled() -> Deck {
-        let mut d = Deck {
-            count_dealt: 0,
-            cards: [0; 52],
-        };
+        let mut d = Deck { cards: Vec::new() };
 
-        let mut value = 0;
-        for x in d.cards.iter_mut() {
-            *x = value;
-            value += 1;
+        for value in 0..52 {
+            d.cards.push(Card::from_value(value).ok().unwrap());
         }
         d
     }
@@ -70,17 +34,6 @@ impl Deck {
         d
     }
 
-    /// Just pretend nothing was ever dealt.
-    pub fn reset_unshuffled(&mut self) {
-        self.count_dealt = 0;
-    }
-
-    /// Shuffle the cards - just as if you were starting with a fresh shuffled deck.
-    pub fn reset_shuffled(&mut self) {
-        self.count_dealt = 0;
-        self.shuffle();
-    }
-
     fn shuffle(&mut self) {
         let mut rng = rand::thread_rng();
         rng.shuffle(&mut self.cards);
@@ -88,30 +41,30 @@ impl Deck {
 
     /// An attempt to get a card from the deck. There might not be enough.
     pub fn draw(&mut self) -> Result<Card, DeckError> {
-        if self.count_dealt + 1 > 52 {
-            Err(DeckError::NotEnoughCards)
-        } else {
-            let value = self.cards[self.count_dealt];
-            self.count_dealt += 1;
-
-            let card = create_card_for_value(value);
-            Ok(card)
+        match self.cards.pop() {
+            Some(c) => Ok(c),
+            None => Err(DeckError::NotEnoughCards),
         }
     }
 
     /// An attempt to get n cards from the deck wrapped in a Vec. There might not be enough.
     pub fn draw_n(&mut self, n: usize) -> Result<Vec<Card>, DeckError> {
-        if self.count_dealt + n > 52 {
-            Err(DeckError::NotEnoughCards)
-        } else {
+        if self.cards.len() >= n {
             let mut cards = Vec::new();
-
+            // For as many cards as are requested
             for _ in 0..n {
-                cards.push(self.draw().ok().unwrap());
+                // Push a new card
+                cards.push(
+                    // We get the card to push from self.draw()
+                    match self.draw() {
+                        Ok(c) => c,
+                        Err(_) => return Err(DeckError::NotEnoughCards),
+                    },
+                );
             }
-
             Ok(cards)
+        } else {
+            Err(DeckError::NotEnoughCards)
         }
     }
 }
-

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -67,4 +67,16 @@ impl Deck {
             Err(DeckError::NotEnoughCards)
         }
     }
+
+    pub fn remove(&mut self, card: Card) -> Result<Card, DeckError> {
+        // TODO: Use self.cards.remove_item when the API stablizes
+        // match self.cards.remove_item(c) {
+        //     Some(c) => Ok(c),
+        //     None => Err(DeckError::CardNotInDeck)
+        // }
+        match self.cards.iter().position(|c| *c == card) {
+            Some(index) => Ok(self.cards.remove(index)),
+            None => Err(DeckError::CardNotInDeck),
+        }
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -81,3 +81,45 @@ fn draw_too_many_cards() {
     let mut deck = Deck::new_shuffled();
     deck.draw_n(53).ok().unwrap();
 }
+
+#[test]
+fn remove_card() {
+    let mut deck = Deck::new_shuffled();
+
+    let card = Card::new(Value::Ace, Suit::Spades);
+
+    // Remove the requested card from the deck
+    deck.remove(card).ok().unwrap();
+
+    // The card we removed should not be in any of the remaining 51 cards
+    for current_card in deck.draw_n(51).ok().unwrap() {
+        if current_card == card {
+            panic!()
+        }
+    }
+}
+
+#[test]
+#[should_panic]
+fn double_remove_card() {
+    let mut deck = Deck::new_shuffled();
+
+    let card = Card::new(Value::Ace, Suit::Spades);
+
+    // This one works
+    deck.remove(card).ok().unwrap();
+
+    // This one panics
+    deck.remove(card).ok().unwrap();
+}
+
+#[test]
+#[should_panic]
+fn remove_drawn_card() {
+    let mut deck = Deck::new_shuffled();
+
+    let card = deck.draw().ok().unwrap();
+
+    // Panics becuase we already drew the card
+    deck.remove(card).ok().unwrap();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 extern crate cards;
 
 use cards::{
-    card::{Card, Suit, Value, get_value_for_card},
+    card::{Card, Suit, Value},
     deck::Deck,
 };
 
@@ -31,8 +31,7 @@ fn draw_all_cards() {
 
 // translates a card to a value between 0 and 51 inclusive
 fn card_to_value(card: Card) -> usize {
-
-    let value = 4*match card.value {
+    let value = 4 * match card.value {
         Value::Two => 0,
         Value::Three => 1,
         Value::Four => 2,
@@ -81,12 +80,4 @@ fn draw_all_cards_and_check() {
 fn draw_too_many_cards() {
     let mut deck = Deck::new_shuffled();
     deck.draw_n(53).ok().unwrap();
-}
-
-#[test]
-fn reset_deck() {
-    let mut deck = Deck::new_unshuffled();
-    deck.draw_n(52).ok().unwrap();
-    deck.reset_unshuffled();
-    deck.draw_n(52).ok().unwrap();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,9 @@
 extern crate cards;
 
-use cards::deck::{Deck};
-use cards::card::{Card, Suit, Value};
+use cards::{
+    card::{Card, Suit, Value, get_value_for_card},
+    deck::Deck,
+};
 
 #[test]
 fn draw_a_card() {
@@ -73,7 +75,6 @@ fn draw_all_cards_and_check() {
         }
     }
 }
-
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
Fixes #3 

Warning: I'm pretty sure this change requires a major version bump due to breaking API changes.

I came here to solve #3 and add a `Deck::remove()` method, but after some digging and looking at some `TODO` line items in the code, I decided it was easier in the long run to switch `Deck` to use a `Vec<Card>` instead of a slice to keep track of cards.

## Includes the following public API additions:
- `Deck::remove(Card) -> Result<Card, DeckError>`

## Includes the following private API additions:
- Added `fn from_value(u8)` to `Card::Suit` and `Card::Value`
- Added `pub(crate) fn from_value(u8)` to `Card`

## Includes the following public API deprecation:
I removed these because they were either hard to implement or weren't necessary. I'd be open to adding them back in.
- Removed `Deck::reset_shuffled()`
- Removed `Deck::reset_unshuffled()`
- Removed `Deck.count_dealt`

## Includes the following private API deprecation:
- Removed `create_card_for_value()` from tests/lib.rs

I am totally open to making this a conversation. If you think any of these changes shouldn't be made, or should be changed, ping me! Also feel free to push changes to my branch.